### PR TITLE
fixed templates as per Vinod's suggestion. 1) allowing CF to assigne …

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -23,7 +23,5 @@ project:
     QSS3BucketName: $[taskcat_autobucket]
 tests:
   tm-targets:
-    parameters:
-      NLBName: traffic-mirror-nlb1
     regions:
       - us-west-2

--- a/templates/vpc-traffic-mirroring-primary.template.yaml
+++ b/templates/vpc-traffic-mirroring-primary.template.yaml
@@ -1,5 +1,10 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: VPC Traffic Mirroring primary template. (qs-1s0om7h3r)
+
+Description: >- 
+  VPC Traffic Mirroring primary template. Template creates VPC Traffic
+  Mirroring target in a new VPC with Suricata installed on the Amazon Linux 2
+  instance(s) (qs-1s0om7h3r).
+
 Metadata:
   QSLint:
     Exclusions: [W9901]
@@ -22,6 +27,7 @@ Metadata:
     - QSS3BucketName
     - Quick Start
     - SSH
+    - ENI
     - customizing
   'AWS::CloudFormation::Interface':
     ParameterGroups:
@@ -55,9 +61,8 @@ Metadata:
       - Label:
           default: Amazon VPC Traffic Mirroring target configuration
         Parameters:
-          - NLBName
+          - TrafficMirrorTargetType
           - NLBScheme
-          - TargetGroupName
           - NumTargetEC2Instances
           - TargetEC2InstanceType
           - TargetEC2InstanceRootVolumeSize
@@ -92,12 +97,10 @@ Metadata:
         default: Key pair name
       NumBastionHosts:
         default: Number of bastion hosts
-      NLBName:
-        default: Network Load Balancer name
+      TrafficMirrorTargetType:
+        default: Traffic mirror target type
       NLBScheme:
         default: Network Load Balancer scheme
-      TargetGroupName:
-        default: Target group name
       NumTargetEC2Instances:
         default: Number of target EC2 instances
       TargetEC2InstanceType:
@@ -123,6 +126,7 @@ Metadata:
       VPCCIDR:
         default: VPC CIDR     
   cfn-lint: { config: { ignore_checks: [E9007] } }
+
 Parameters:
   AvailabilityZones:
     Description: List of Availability Zones to use for the subnets in the VPC.
@@ -232,14 +236,12 @@ Parameters:
     Default: 10.0.144.0/20
     Description: CIDR block for the public DMZ subnet 2, located in Availability Zone 2.
     Type: String
-  NLBName:
-    Description: >-
-      Network Load Balancer name. This name must be unique within your AWS
-      account and can have a maximum of 32 alphanumeric characters and 
-      hyphens. A name cannot begin or end with a hyphen.
+  TrafficMirrorTargetType:
+    Description: 'Traffic mirror target type: NLB or ENI.'
     Type: String
-    Default: traffic-mirror-nlb1
-    ConstraintDescription: Must be a valid NLB Name
+    Default: NLB
+    AllowedValues: ['NLB', 'ENI']
+    ConstraintDescription: Must be a valid traffic mirror target type
   NLBScheme:
     Description: >-
       Network Load Balancer scheme. Valid values are internet-facing and 
@@ -248,11 +250,6 @@ Parameters:
     AllowedValues: ['internet-facing', 'internal']
     Type: String
     ConstraintDescription: 'Must be a valid NLB scheme'
-  TargetGroupName:
-    Description: Target group name.
-    Type: String
-    Default: traffic-mirror-nlb1-tg1
-    ConstraintDescription: Must be a valid target group name
   NumTargetEC2Instances:
     AllowedValues:
       - '1'
@@ -345,11 +342,14 @@ Parameters:
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
     Default: 10.0.0.0/16
     Description: CIDR Block for the VPC.
-    Type: String  
+    Type: String
+
 Conditions:
   UsingDefaultBucket: !Equals
     - !Ref QSS3BucketName
     - 'aws-quickstart'
+  TargetTypeNLB: !Equals [!Ref TrafficMirrorTargetType, "NLB"]
+
 Resources:
   VPCStack:
     Type: AWS::CloudFormation::Stack
@@ -396,18 +396,17 @@ Resources:
 
   TrafficMirrorNLBStack:
     Type: AWS::CloudFormation::Stack
+    Condition: TargetTypeNLB
     Properties:
       TemplateURL: !Sub
         - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/vpc-traffic-mirroring-target-nlb.template.yaml
         - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
           S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
       Parameters:
-        NLBName: !Ref NLBName
         NLBScheme: !Ref NLBScheme
         NLBSubnet1ID: !GetAtt [VPCStack, Outputs.PrivateSubnet1AID]
         NLBSubnet2ID: !GetAtt [VPCStack, Outputs.PrivateSubnet2AID]
-        VPCID: !GetAtt [VPCStack, Outputs.VPCID]     
-        TargetGroupName: !Ref TargetGroupName
+        VPCID: !GetAtt [VPCStack, Outputs.VPCID]
 
   TrafficMirrorTargetInstanceStack:
     Type: AWS::CloudFormation::Stack
@@ -426,7 +425,8 @@ Resources:
         TargetEC2InstanceRootVolumeSize: !Ref TargetEC2InstanceRootVolumeSize
         KeyPairName: !Ref KeyPairName
         BastionSecurityGroupID: !GetAtt [BastionStack, Outputs.BastionSecurityGroupID]
-        TargetGroupARN: !GetAtt [TrafficMirrorNLBStack, Outputs.TargeGroupARN]
+        TrafficMirrorTargetType: !Ref TrafficMirrorTargetType
+        TargetGroupARN: !If [TargetTypeNLB, !GetAtt [TrafficMirrorNLBStack, Outputs.TargeGroupARN], !Ref AWS::NoValue]
 
 Outputs:
   Postdeployment:

--- a/templates/vpc-traffic-mirroring-target-instance.template.yaml
+++ b/templates/vpc-traffic-mirroring-target-instance.template.yaml
@@ -1,6 +1,11 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
-Description: VPC Traffic Mirroring target instance template. (qs-1s0om7h6b)
+Description: >- 
+  VPC Traffic Mirroring instance template. Template creates Amazon Linux 2
+  EC2 instance(s) with Suricata installed on it. Instances are launched in auto
+  scaling group. If traffic mirror target type is set to NLB, template
+  associates auto scaling group with a target group. Template can also be
+  launched as a stand alone template (qs-1s0om7h6b).
 
 Metadata:
   QSLint:
@@ -29,7 +34,7 @@ Metadata:
     - Subnet
     - Suricata
     - NLB
-    - Interface
+    - ENI
     - c5n.large
     - TrafficMirrorTargetType
   AWS::CloudFormation::Interface:
@@ -85,7 +90,8 @@ Parameters:
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
   VPCID:
     Description: ID of the VPC (e.g., vpc-0343606e).
-    Type: 'AWS::EC2::VPC::Id'
+    Type: AWS::EC2::VPC::Id
+    ConstraintDescription: Must be a valid VPC ID
   Subnet1ID:
     Description: ID of Subnet 1 to be associated (e.g., subnet-11223344, subnet-55667788).
     Type: AWS::EC2::Subnet::Id
@@ -132,7 +138,6 @@ Parameters:
   TargetEC2InstanceRootVolumeSize:
     Description: Target instance disk size in GB. Default is set to 8GB.
     Default: 8
-    AllowedValues: [8]
     Type: Number
     ConstraintDescription: Should be a valid instance size in GB
   KeyPairName:
@@ -142,20 +147,21 @@ Parameters:
   LatestAmazonLinux2AmiId:
     Description: Latest Amazon Linux 2 AMI ID.
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-    Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'  
+    Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
   BastionSecurityGroupID:
     Description: ID of bastion security group to allow access to targets.
-    Type: 'AWS::EC2::SecurityGroup::Id'
+    Type: AWS::EC2::SecurityGroup::Id
     ConstraintDescription: Must be a valid security group ID
   TrafficMirrorTargetType:
-    Description: 'Traffic mirror target type: NLB or Interface.'
+    Description: 'Traffic mirror target type: NLB or ENI.'
     Type: String
     Default: NLB
-    AllowedValues: ['NLB', 'Interface']
+    AllowedValues: ['NLB', 'ENI']
     ConstraintDescription: Must be a valid traffic mirror target type    
   TargetGroupARN:
     Description: Target group ARN. Not required if TrafficMirrorTargetType is not NLB.
     Type: String
+    Default: 'arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067'
     ConstraintDescription: Must be a valid target group ARN
 
 Conditions:
@@ -280,12 +286,9 @@ Resources:
           systemctl enable httpd
           systemctl start httpd
 
-      LaunchConfigurationName: !Sub "${AWS::StackName}-launch-config"
-
   TargetInstanceASG:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
-      AutoScalingGroupName: !Sub "${AWS::StackName}-target-asg"
       LaunchConfigurationName: !Ref TargetInstanceConfig
       MinSize: !Ref NumTargetEC2Instances
       MaxSize: !Ref NumTargetEC2Instances

--- a/templates/vpc-traffic-mirroring-target-nlb.template.yaml
+++ b/templates/vpc-traffic-mirroring-target-nlb.template.yaml
@@ -1,6 +1,9 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
-Description: VPC Traffic Mirroring target template. (qs-1s0om7h6j)
+Description: >- 
+  VPC Traffic Mirroring NLB template. Template is launched if traffic mirror
+  target type is set to NLB. Template creates NLB to use as Traffic Mirroring
+  target. Template can also be launched standalone (qs-1s0om7h6j).
 
 Metadata:
   QSLint:
@@ -29,7 +32,6 @@ Metadata:
       - Label:
           default: 'Network Load Balancer Configuration'
         Parameters:
-          - NLBName
           - NLBScheme
           - NLBSubnet1ID
           - NLBSubnet2ID
@@ -37,33 +39,20 @@ Metadata:
           default: 'Target group configuration'
         Parameters:
           - VPCID
-          - TargetGroupName
     ParameterLabels:
       VPCID:
-        default: VPC ID  
-      NLBName:
-        default: Network Load Balancer Name
+        default: VPC ID
       NLBScheme:
         default: Network Load Balancer Scheme
       NLBSubnet1ID:
         default: ID of Subnet 1 to be associated with NLB
       NLBSubnet2ID:
-        default: ID of Subnet 2 to be associated with NLB        
-      TargetGroupName:
-        default: Target group name
+        default: ID of Subnet 2 to be associated with NLB
 
 Parameters:
   VPCID:
     Description: ID of the VPC (e.g., vpc-0343606e).
     Type: 'AWS::EC2::VPC::Id'
-  NLBName:
-    Description: >-
-      Network Load Balancer name. This name must be unique within your AWS
-      account and can have a maximum of 32 alphanumeric characters and 
-      hyphens. A name cannot begin or end with a hyphen.
-    Type: String
-    Default: tm-target-nlb1
-    ConstraintDescription: Must be a valid ELB Name
   NLBScheme:
     Description: >-
       Network Load Balancer scheme. Valid values are internet-facing and 
@@ -79,18 +68,12 @@ Parameters:
   NLBSubnet2ID:
     Description: ID of Subnet 2 to be associated with NLB (e.g., subnet-11223344, subnet-55667788).
     Type: AWS::EC2::Subnet::Id
-    ConstraintDescription: Must be a valid subnet ID    
-  TargetGroupName:
-    Description: Target group name.
-    Type: String
-    Default: tm-targets-tg1
-    ConstraintDescription: Must be a valid target group name
+    ConstraintDescription: Must be a valid subnet ID
 
 Resources:
   Nlb:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      Name: !Ref NLBName
       Scheme: !Ref NLBScheme
       Type: network
       Subnets: 
@@ -103,7 +86,6 @@ Resources:
   TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      Name: !Ref TargetGroupName
       Port: 4789
       Protocol: UDP
       TargetGroupAttributes:


### PR DESCRIPTION
Fixed templates as per [Vinod's suggestion](https://github.com/aws-quickstart/quickstart-amazon-vpc-traffic-mirroring/pull/2). 

1. Allowing CF to create names
2. NLB stack not created when not chosen

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
